### PR TITLE
Added sqlite support

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -1,0 +1,167 @@
+Database = {}
+local db = {}
+
+Database.error = function(errorMessage)
+	if db ~= nil then
+		if db:errcode() ~= sqlite3.OK then
+			LOG("Database error code: " .. db:errcode())
+			LOG("Database error message: " .. db:errmsg())
+		end
+		Database.close()
+	end
+	error(errorMessage)
+end
+
+Database.open = function(path)
+	db = sqlite3.open("essentials.sqlite3")
+	if (db == nil) or (not db:isopen()) then
+		--This error could be caused by insufficient write permissions
+		--Or a corrupted database
+		checkTable.finalize()
+		Database.error("Could not initialize database")
+	end
+end
+
+Database.close = function()
+	db:close()
+end
+
+Database.pragma = function(name, value)
+	if db:exec("PRAGMA " .. name .. " = " .. value) ~= sqlite3.OK then
+		Database.error("Could not load settings")
+	end
+end
+
+Database.initializeTable = function(name, columns)
+	local status = db:exec("CREATE TABLE IF NOT EXISTS " .. name .. "(" .. columns .. ")")
+
+	local checkTable = db:prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+	checkTable:bind(1, name)
+
+	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
+		Database.error("Could not initialize table " .. name)
+	end
+end
+
+Database.getUserId = function(Username, UUID)
+	local userIdQuery
+	if (UUID == nil) or (string.len(UUID) == 0) then
+		UUID = nil
+		userIdQuery = db:prepare("SELECT UserId FROM Main WHERE Username=?")
+		userIdQuery:bind(1, Username)
+	else
+		userIdQuery = db:prepare("SELECT UserId FROM Main WHERE UUID=?")
+		userIdQuery:bind(1, UUID)
+	end
+
+	if userIdQuery:step() ~= sqlite3.ROW then
+		local insertQuery = db:prepare("INSERT INTO Main (Username, UUID) VALUES (?1, ?2)")
+		insertQuery:bind_values(Username, UUID)
+		local insertStatus = insertQuery:step()
+		insertQuery:finalize()
+		if insertStatus ~= sqlite3.DONE then
+			userIdQuery:finalize()
+			return nil
+		end
+		userIdQuery:finalize()
+		return Database.getUserId(Username, UUID)
+	end
+	local userId = userIdQuery:get_value(0)
+	userIdQuery:finalize()
+	return userId
+end
+
+Database.getRow = function(table, condition, parameters)
+	local rowSearch = db:prepare("SELECT * FROM " .. table .. " WHERE " .. condition)
+	for i=1, math.min(#parameters, rowSearch:bind_parameter_count()) do
+		rowSearch:bind(i, parameters[i])
+	end
+	if rowSearch:step() == sqlite3.ROW then
+		local row = rowSearch:get_values()
+		rowSearch:finalize()
+		return row
+	else
+		rowSearch:finalize()
+		return nil
+	end
+end
+
+Database.getRows = function(table, condition, parameters)
+	local rows = {}
+	local rowSearch = db:prepare("SELECT * FROM " .. table .. " WHERE " .. condition)
+	for i=1, math.min(#parameters, rowSearch:bind_parameter_count()) do
+		rowSearch:bind(i, parameters[i])
+	end
+
+	local i=1
+	while rowSearch:step() == sqlite3.ROW do
+		rows[i] = rowSearch:get_values()
+		i = i + 1
+	end
+	rowSearch:finalize()
+
+	return rows
+end
+
+Database.rowExists = function(table, condition, parameters)
+	return Database.getRow(table, condition, parameters) ~= nil
+end
+
+Database.insertRow = function(table, keyValuePairs, parameters)
+	local columns = ""
+	local values = ""
+	for k, v in pairs(keyValuePairs) do
+		columns = columns .. k .. ", "
+		values = values .. v .. ", "
+	end
+	columns = string.sub(columns, 1, -3)
+	values = string.sub(values, 1, -3)
+
+	local stmt = db:prepare("INSERT INTO " .. table .. " (" .. columns .. ") VALUES (" .. values .. ")")
+	for i=1, math.min(#parameters, stmt:bind_parameter_count()) do
+		stmt:bind(i, parameters[i])
+	end
+	if stmt:step() ~= sqlite3.DONE then
+		stmt:finalize()
+		Database.error("Error attempting to insert a database row")
+	end
+	stmt:finalize()
+end
+
+Database.updateRow = function(table, condition, keyValuePairs, parameters)
+	local set = ""
+	for k, v in pairs(keyValuePairs) do
+		set = set .. k .. "=" .. v .. ", "
+	end
+	set = string.sub(set, 1, -3)
+
+	local stmt = db:prepare("UPDATE " .. table .. " SET " .. set .. " WHERE " .. condition)
+	for i=1, math.min(#parameters, stmt:bind_parameter_count()) do
+		stmt:bind(i, parameters[i])
+	end
+	if stmt:step() ~= sqlite3.DONE then
+		stmt:finalize()
+		Database.error("Error attempting to update database value(s)")
+	end
+	stmt:finalize()
+end
+
+Database.upsertRow = function(table, condition, keyValuePairs, parameters)
+	if Database.rowExists(table, condition, parameters) then
+		Database.updateRow(table, condition, keyValuePairs, parameters)
+	else
+		Database.insertRow(table, keyValuePairs, parameters)
+	end
+end
+
+Database.deleteRow = function(table, condition, parameters)
+	local stmt = db:prepare("DELETE FROM " .. table .. " WHERE " .. condition)
+	for i=1, math.min(#parameters, stmt:bind_parameter_count()) do
+		stmt:bind(i, parameters[i])
+	end
+	if stmt:step() ~= sqlite3.DONE then
+		stmt:finalize()
+		Database.error("Error attempting to remove a database row")
+	end
+	stmt:finalize()
+end

--- a/hooks.lua
+++ b/hooks.lua
@@ -67,44 +67,68 @@ function OnUpdatingSign(World, BlockX, BlockY, BlockZ, Line1, Line2, Line3, Line
 end
 
 function OnPlayerBreakingBlock(Player, BlockX, BlockY, BlockZ, BlockFace, BlockType, BlockMeta)
-	if (Jailed[Player:GetName()] == true) and (IsDiggingEnabled == false) then 
+	local UserId = GetUserIdFromUsername(Player:GetName(), Player:GetUUID())
+
+	local prisonerSearch = database:prepare("SELECT * FROM Prisoners WHERE UserId=?")
+	prisonerSearch:bind(1, UserId)
+	if (prisonerSearch:step() == sqlite3.ROW) and not IsDiggingEnabled then
 		Player:SendMessageWarning("You are jailed")
+		prisonerSearch:finalize()
 		return true
-	else
-		return false
 	end
+	prisonerSearch:finalize()
+	return false
 end
 
 function OnPlayerPlacingBlock(Player, BlockX, BlockY, BlockZ, BlockFace, CursorX, CursorY, CursorZ, BlockType)
-	if (Jailed[Player:GetName()] == true) and (IsPlaceEnabled == false) then 
+	local UserId = GetUserIdFromUsername(Player:GetName(), Player:GetUUID())
+
+	local prisonerSearch = database:prepare("SELECT * FROM Prisoners WHERE UserId=?")
+	prisonerSearch:bind(1, UserId)
+	if (prisonerSearch:step() == sqlite3.ROW) and not IsPlaceEnabled  then
 		Player:SendMessageWarning("You are jailed")
+		prisonerSearch:finalize()
 		return true
-	else 
-		return false
 	end
+	prisonerSearch:finalize()
+	return false
 end
 
 function OnExecuteCommand(Player, CommandSplit)
 	if Player == nil then
 		return false
-	elseif (Jailed[Player:GetName()] == true) and (AreCommandsEnabled == false) then
-		Player:SendMessageWarning("You are jailed") 
-		return true
-	else 
-		return false
 	end
+
+	local UserId = GetUserIdFromUsername(Player:GetName(), Player:GetUUID())
+
+	local prisonerSearch = database:prepare("SELECT * FROM Prisoners WHERE UserId=?")
+	prisonerSearch:bind(1, UserId)
+	if (prisonerSearch:step() == sqlite3.ROW) and not AreCommandsEnabled then
+		Player:SendMessageWarning("You are jailed")
+		prisonerSearch:finalize()
+		return true
+	end
+	prisonerSearch:finalize()
+	return false
 end
 
 function OnChat(Player, Message)
 	if Muted[Player:GetName()] == true then 
 		Player:SendMessageWarning("You are muted")
 		return true
-	elseif (Jailed[Player:GetName()] == true) and (IsChatEnabled == false) then 
-		Player:SendMessageWarning("You are jailed")
-		return true
-	else 
-		return false
 	end
+
+	local UserId = GetUserIdFromUsername(Player:GetName(), Player:GetUUID())
+
+	local prisonerSearch = database:prepare("SELECT * FROM Prisoners WHERE UserId=?")
+	prisonerSearch:bind(1, UserId)
+	if (prisonerSearch:step() == sqlite3.ROW) and not IsChatEnabled then
+		Player:SendMessageWarning("You are jailed")
+		prisonerSearch:finalize()
+		return true
+	end
+	prisonerSearch:finalize()
+	return false
 end
 
 function OnWorldTick(World, TimeDelta)

--- a/hooks.lua
+++ b/hooks.lua
@@ -67,30 +67,22 @@ function OnUpdatingSign(World, BlockX, BlockY, BlockZ, Line1, Line2, Line3, Line
 end
 
 function OnPlayerBreakingBlock(Player, BlockX, BlockY, BlockZ, BlockFace, BlockType, BlockMeta)
-	local UserId = GetUserIdFromUsername(Player:GetName(), Player:GetUUID())
+	local UserId = Database.getUserId(Player:GetName(), Player:GetUUID())
 
-	local prisonerSearch = database:prepare("SELECT * FROM Prisoners WHERE UserId=?")
-	prisonerSearch:bind(1, UserId)
-	if (prisonerSearch:step() == sqlite3.ROW) and not IsDiggingEnabled then
+	if (not IsDiggingEnabled) and (Database.rowExists("Prisoners", "UserId=?1", { UserId })) then
 		Player:SendMessageWarning("You are jailed")
-		prisonerSearch:finalize()
 		return true
 	end
-	prisonerSearch:finalize()
 	return false
 end
 
 function OnPlayerPlacingBlock(Player, BlockX, BlockY, BlockZ, BlockFace, CursorX, CursorY, CursorZ, BlockType)
-	local UserId = GetUserIdFromUsername(Player:GetName(), Player:GetUUID())
+	local UserId = Database.getUserId(Player:GetName(), Player:GetUUID())
 
-	local prisonerSearch = database:prepare("SELECT * FROM Prisoners WHERE UserId=?")
-	prisonerSearch:bind(1, UserId)
-	if (prisonerSearch:step() == sqlite3.ROW) and not IsPlaceEnabled  then
+	if (not IsPlaceEnabled) and (Database.rowExists("Prisoners", "UserId=?1", { UserId })) then
 		Player:SendMessageWarning("You are jailed")
-		prisonerSearch:finalize()
 		return true
 	end
-	prisonerSearch:finalize()
 	return false
 end
 
@@ -99,16 +91,12 @@ function OnExecuteCommand(Player, CommandSplit)
 		return false
 	end
 
-	local UserId = GetUserIdFromUsername(Player:GetName(), Player:GetUUID())
+	local UserId = Database.getUserId(Player:GetName(), Player:GetUUID())
 
-	local prisonerSearch = database:prepare("SELECT * FROM Prisoners WHERE UserId=?")
-	prisonerSearch:bind(1, UserId)
-	if (prisonerSearch:step() == sqlite3.ROW) and not AreCommandsEnabled then
+	if (not AreCommandsEnabled) and (Database.rowExists("Prisoners", "UserId=?1", { UserId })) then
 		Player:SendMessageWarning("You are jailed")
-		prisonerSearch:finalize()
 		return true
 	end
-	prisonerSearch:finalize()
 	return false
 end
 
@@ -118,16 +106,12 @@ function OnChat(Player, Message)
 		return true
 	end
 
-	local UserId = GetUserIdFromUsername(Player:GetName(), Player:GetUUID())
+	local UserId = Database.getUserId(Player:GetName(), Player:GetUUID())
 
-	local prisonerSearch = database:prepare("SELECT * FROM Prisoners WHERE UserId=?")
-	prisonerSearch:bind(1, UserId)
-	if (prisonerSearch:step() == sqlite3.ROW) and not IsChatEnabled then
+	if (not IsChatEnabled) and (Database.rowExists("Prisoners", "UserId=?1", { UserId })) then
 		Player:SendMessageWarning("You are jailed")
-		prisonerSearch:finalize()
 		return true
 	end
-	prisonerSearch:finalize()
 	return false
 end
 

--- a/main.lua
+++ b/main.lua
@@ -7,7 +7,7 @@ TpRequestTimeLimit = 0
 TpsCache = {}
 GlobalTps = {}
 Muted = {}
-database = {}
+db = {}
 
 --Initialize the plugin
 function Initialize(Plugin)
@@ -52,41 +52,23 @@ function Initialize(Plugin)
 	cRoot:Get():ForEachPlayer(CheckPlayer)
 
 	--Open database and initialize tables if necessary
-	database = sqlite3.open("essentials.sqlite3")
-	local checkTable = database:prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
-	if checkTable == nil then
-		--This error could be caused by insufficient write permissions
-		--Or a corrupted database
-		error("Could not initialize database")
-  end
+	Database.open("essentials.sqlite3")
 	local status;
 	--Enable foreign key support for the database
-	status = database:exec("PRAGMA foreign_keys = ON")
-	if status ~= sqlite3.OK then
-		error("Could not configure foreign keys")
-	end
-	status = database:exec([[CREATE TABLE IF NOT EXISTS Main(
+	Database.pragma("foreign_keys", "ON")
+	Database.initializeTable("Main", [[
 		UserId INTEGER PRIMARY KEY AUTOINCREMENT,
 		UUID VARCHAR(36),
 		Username VARCHAR(16)
-	)]])
-	checkTable:bind(1, "Main")
-	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
-		error("Could not initialize table Main")
-	end
-	database:exec([[CREATE TABLE IF NOT EXISTS Jails(
+	]])
+	Database.initializeTable("Jails", [[
 		Name VARCHAR(255) UNIQUE NOT NULL,
 		World VARCHAR(255) NOT NULL,
 		X SINGLE NOT NULL,
 		Y SINGLE NOT NULL,
 		Z SINGLE NOT NULL
-	)]])
-	checkTable:reset()
-	checkTable:bind(1, "Jails")
-	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
-		error("Could not initialize table Jails")
-	end
-	database:exec([[CREATE TABLE IF NOT EXISTS Prisoners(
+	]])
+	Database.initializeTable("Prisoners", [[
 		UserId INT UNIQUE,
 		JailName VARCHAR(255),
 		ExpiryTicks INT NOT NULL,
@@ -96,25 +78,15 @@ function Initialize(Plugin)
 		OldZ SINGLE NOT NULL,
 		FOREIGN KEY(UserId) REFERENCES Main(UserId),
 		FOREIGN KEY(JailName) REFERENCES Jails(Name)
-	)]])
-	checkTable:reset()
-	checkTable:bind(1, "Prisoners")
-	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
-		error("Could not initialize table Prisoners")
-	end
-	database:exec([[CREATE TABLE IF NOT EXISTS Warps(
+	]])
+	Database.initializeTable("Warps", [[
 		Name VARCHAR(255) UNIQUE NOT NULL,
 		World VARCHAR(255) NOT NULL,
 		X SINGLE NOT NULL,
 		Y SINGLE NOT NULL,
 		Z SINGLE NOT NULL
-	)]])
-	checkTable:reset()
-	checkTable:bind(1, "Warps")
-	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
-		error("Could not initialize table Warps")
-	end
-	database:exec([[CREATE TABLE IF NOT EXISTS Homes(
+	]])
+	Database.initializeTable("Homes", [[
 		UserId INT,
 		Name VARCHAR(255) NOT NULL,
 		World VARCHAR(255) NOT NULL,
@@ -122,13 +94,7 @@ function Initialize(Plugin)
 		Y SINGLE NOT NULL,
 		Z SINGLE NOT NULL,
 		FOREIGN KEY(UserId) REFERENCES Main(UserId)
-	)]])
-	checkTable:reset()
-	checkTable:bind(1, "Homes")
-	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
-		error("Could not initialize table Homes")
-	end
-	checkTable:finalize()
+	]])
 
 	LOG("Initialised " .. Plugin:GetName() .. " v." .. Plugin:GetVersion())
 	return true
@@ -136,29 +102,6 @@ function Initialize(Plugin)
 end
 
 function OnDisable()
-	database:close()
+	Database:close()
 	LOG("Disabled Essentials!")
-end
-
-function GetUserIdFromUsername(Username, UUID)
-	if UUID == nil or string.len(UUID) == 0 then
-		UUID = nil
-	end
-
-	local userIdQuery = database:prepare("SELECT UserId FROM Main WHERE Username=?")
-	userIdQuery:bind(1, Username)
-	if userIdQuery:step() ~= sqlite3.ROW then
-		local insertQuery = database:prepare("INSERT INTO Main (Username, UUID) VALUES (?1, ?2)")
-		insertQuery:bind_values(Username, UUID)
-		local insertStatus = insertQuery:step()
-		if insertStatus ~= sqlite3.DONE then
-			insertQuery:finalize()
-			return nil
-		end
-		insertQuery:finalize()
-		return GetUserIdFromUsername(Username)
-	end
-	local userId = userIdQuery:get_value(0)
-	userIdQuery:finalize()
-	return userId
 end

--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,4 @@
 --Global variables
-warps = {}
-jails = {}
 lastsender = {}
 ticks = {}
 timer = {}
@@ -8,12 +6,11 @@ BackCoords = {}
 TpRequestTimeLimit = 0
 TpsCache = {}
 GlobalTps = {}
-Jailed = {}
 Muted = {}
+database = {}
 
 --Initialize the plugin
 function Initialize(Plugin)
-
 	dofile(cPluginManager:GetPluginsPath() .. "/InfoReg.lua")
 
 	Plugin:SetName(g_PluginInfo.Name)
@@ -37,37 +34,8 @@ function Initialize(Plugin)
 	
 	RegisterPluginInfoConsoleCommands();
 
-	--Read the warps (stored in ini file)
-	WarpsINI = cIniFile()
-	if (WarpsINI:ReadFile("warps.ini")) then
-		warpNum = WarpsINI:GetNumKeys();
-		for i=0, warpNum do
-			local Tag = WarpsINI:GetKeyName(i)
-			warps[Tag] = {}
-			warps[Tag]["w"] = WarpsINI:GetValue( Tag , "w")
-			warps[Tag]["x"] = WarpsINI:GetValueI( Tag , "x")
-			warps[Tag]["y"] = WarpsINI:GetValueI( Tag , "y")
-			warps[Tag]["z"] = WarpsINI:GetValueI( Tag , "z")
-		end
-	end
-
 	--Set dirs which will be used later on
 	localdir = Plugin:GetLocalFolder()
-	homeDir = Plugin:GetLocalFolder().."/homes"
-
-	--Read jails (from ini file)
-	JailsINI = cIniFile()
-	if (JailsINI:ReadFile("jails.ini")) then
-		jailNum = JailsINI:GetNumKeys();
-		for i=0, jailNum do
-			local Tag = JailsINI:GetKeyName(i)
-			jails[Tag] = {}
-			jails[Tag]["w"] = JailsINI:GetValue( Tag , "w")
-			jails[Tag]["x"] = JailsINI:GetValueI( Tag , "x")
-			jails[Tag]["y"] = JailsINI:GetValueI( Tag , "y")
-			jails[Tag]["z"] = JailsINI:GetValueI( Tag , "z")
-		end
-	end
 
 	UsersINI = cIniFile()
 	UsersINI:ReadFile("users.ini")
@@ -82,13 +50,115 @@ function Initialize(Plugin)
 	SettingsINI:WriteFile("settings.ini")
 	
 	cRoot:Get():ForEachPlayer(CheckPlayer)
-	
-	--If there's no home folder, plugin will create it
-	if cFile:IsFolder(homeDir) ~= true then
-		cFile:CreateFolder(homeDir)
+
+	--Open database and initialize tables if necessary
+	database = sqlite3.open("essentials.sqlite3")
+	local checkTable = database:prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+	if checkTable == nil then
+		--This error could be caused by insufficient write permissions
+		--Or a corrupted database
+		error("Could not initialize database")
+  end
+	local status;
+	--Enable foreign key support for the database
+	status = database:exec("PRAGMA foreign_keys = ON")
+	if status ~= sqlite3.OK then
+		error("Could not configure foreign keys")
 	end
+	status = database:exec([[CREATE TABLE IF NOT EXISTS Main(
+		UserId INTEGER PRIMARY KEY AUTOINCREMENT,
+		UUID VARCHAR(36),
+		Username VARCHAR(16)
+	)]])
+	checkTable:bind(1, "Main")
+	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
+		error("Could not initialize table Main")
+	end
+	database:exec([[CREATE TABLE IF NOT EXISTS Jails(
+		Name VARCHAR(255) UNIQUE NOT NULL,
+		World VARCHAR(255) NOT NULL,
+		X SINGLE NOT NULL,
+		Y SINGLE NOT NULL,
+		Z SINGLE NOT NULL
+	)]])
+	checkTable:reset()
+	checkTable:bind(1, "Jails")
+	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
+		error("Could not initialize table Jails")
+	end
+	database:exec([[CREATE TABLE IF NOT EXISTS Prisoners(
+		UserId INT UNIQUE,
+		JailName VARCHAR(255),
+		ExpiryTicks INT NOT NULL,
+		OldWorld VARCHAR(255) NOT NULL,
+		OldX SINGLE NOT NULL,
+		OldY SINGLE NOT NULL,
+		OldZ SINGLE NOT NULL,
+		FOREIGN KEY(UserId) REFERENCES Main(UserId),
+		FOREIGN KEY(JailName) REFERENCES Jails(Name)
+	)]])
+	checkTable:reset()
+	checkTable:bind(1, "Prisoners")
+	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
+		error("Could not initialize table Prisoners")
+	end
+	database:exec([[CREATE TABLE IF NOT EXISTS Warps(
+		Name VARCHAR(255) UNIQUE NOT NULL,
+		World VARCHAR(255) NOT NULL,
+		X SINGLE NOT NULL,
+		Y SINGLE NOT NULL,
+		Z SINGLE NOT NULL
+	)]])
+	checkTable:reset()
+	checkTable:bind(1, "Warps")
+	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
+		error("Could not initialize table Warps")
+	end
+	database:exec([[CREATE TABLE IF NOT EXISTS Homes(
+		UserId INT,
+		Name VARCHAR(255) NOT NULL,
+		World VARCHAR(255) NOT NULL,
+		X SINGLE NOT NULL,
+		Y SINGLE NOT NULL,
+		Z SINGLE NOT NULL,
+		FOREIGN KEY(UserId) REFERENCES Main(UserId)
+	)]])
+	checkTable:reset()
+	checkTable:bind(1, "Homes")
+	if (status ~= sqlite3.OK) or (checkTable:step() ~= sqlite3.ROW) then
+		error("Could not initialize table Homes")
+	end
+	checkTable:finalize()
 
 	LOG("Initialised " .. Plugin:GetName() .. " v." .. Plugin:GetVersion())
 	return true
 	--Finish!
+end
+
+function OnDisable()
+	database:close()
+	LOG("Disabled Essentials!")
+end
+
+function GetUserIdFromUsername(Username, UUID)
+	if UUID == nil or string.len(UUID) == 0 then
+		UUID = nil
+	end
+
+	local userIdQuery = database:prepare("SELECT UserId FROM Main WHERE Username=?")
+	userIdQuery:bind(1, Username)
+	if userIdQuery:step() ~= sqlite3.ROW then
+		local insertQuery = database:prepare("INSERT INTO Main (Username, UUID) VALUES (?1, ?2)")
+		insertQuery:bind_values(Username, UUID)
+		local insertStatus = insertQuery:step()
+		if insertStatus ~= sqlite3.DONE then
+			insertQuery:finalize()
+			return nil
+		end
+		insertQuery:finalize()
+		return GetUserIdFromUsername(Username)
+	end
+	local userId = userIdQuery:get_value(0)
+	userIdQuery:finalize()
+	return userId
 end


### PR DESCRIPTION
Currently this sqlite database is used for managing warps, homes, and jails. Everything has been tested and appears to be working correctly. Almost everything behaves the same as it did before. The only noticeable change to the functioning of the plugin was to the jails. I added the feature to teleport a user back to the position they were at when they were initially jailed when they are unjailed. I believe this is how the old essentials plugin behaved and it was easiest to implement it while designing the new database structure. Just let me know if there's something that needs to be improved upon before this can be pulled.

Closes #25